### PR TITLE
fix: notice 응답값 중 is_Admin 삭제

### DIFF
--- a/server/controller/ctrNotice.js
+++ b/server/controller/ctrNotice.js
@@ -3,13 +3,9 @@ const mongoose = require('mongoose');
 
 exports.getNotice = async (req, res) => {
   try {
-    const currentUserId = res.locals.decoded.userInfo.id;
-    // const currentUserId = '6544c9106ec46b098ac68132';
-    const isAdmin = await User.findById(currentUserId);
-    // console.log(userInfo);
     const result = await Notice.find();
     console.log(result);
-    res.status(200).send({ notices: result, isAdmin: isAdmin.is_service_admin });
+    res.status(200).send({ notices: result });
   } catch (err) {
     console.log(err);
     res.status(500).send('SERVER ERROR');
@@ -22,13 +18,17 @@ exports.postNotice = async (req, res) => {
     // const currentUserId = '6544c9106ec46b098ac68132';
     const isAdmin = await User.findById(currentUserId);
     console.log(req.body);
-    const notice = new Notice({
-      title: req.body.title,
-      content: req.body.content,
-    });
-    await notice.save();
-    console.log('result', notice);
-    res.send({ result: notice, message: '공지사항이 성공적으로 생성되었습니다.' });
+    if (isAdmin.is_service_admin) {
+      const notice = new Notice({
+        title: req.body.title,
+        content: req.body.content,
+      });
+      await notice.save();
+      console.log('result', notice);
+      res.send({ result: notice, message: '공지사항이 성공적으로 생성되었습니다.' });
+    } else {
+      res.status(400).send({ message: '공지사항 등록 권한이 없습니다.' });
+    }
   } catch (err) {
     console.log(err);
     res.status(500).send('SERVER ERROR');
@@ -108,12 +108,9 @@ exports.deleteNotice = async (req, res) => {
 
 exports.getNoticeDetail = async (req, res) => {
   try {
-    const currentUserId = res.locals.decoded.userInfo.id;
-    // const currentUserId = '6544c9106ec46b098ac68132';
-    const user = await User.findById(currentUserId);
     const result = await Notice.findById(req.params.notice_id);
     if (result) {
-      res.status(200).send({ result, message: '공지사항 찾기 성공!', isAdmin: user.is_service_admin });
+      res.status(200).send({ result, message: '공지사항 찾기 성공!' });
     } else {
       res.status(400).send({ message: '존재하지 않는 공지사항입니다.' });
     }


### PR DESCRIPTION
- 토큰의 userInfo에 is_service_admin을 보내주어서 따로 클라이언트의 요청마다 관리자여부를 응답값으로 보내줄 필요 없게됨.
- 서버에서 로그인한 유저가 관리자인지 판단 후 관리자가 아닐경우 상태코드와 함께 메시지 전달로 notice 등록/수정권한 없다고 보냄