### PR TITLE
feat: timer schema 수정 및 timer페이지 접속 시 그룹 없어서 방에 입장 못하는 에러 내 개인 그룹 생성해서 해결

### DIFF
--- a/server/controller/ctrGroup.js
+++ b/server/controller/ctrGroup.js
@@ -1,6 +1,4 @@
-
 const { User, Group, Room, Timer, mongoose } = require('../schemas/schema');
-
 
 // 카테고리에 따른 그룹 목록을 반환하는 함수
 exports.getCategoryGroups = async (req, res) => {
@@ -49,22 +47,26 @@ exports.getCategoryGroups = async (req, res) => {
 exports.getCategoryGroupsByUser = async (req, res) => {
   try {
     // 토큰에서 현재 유저 정보 가져오기
-    const userInfo = res.locals.decoded.userInfo;
+    // const userInfo = res.locals.decoded.userInfo;
 
-    if (!userInfo) {
-      return res.status(400).send({
-        isSuccess: false,
-        code: 400,
-        error: '사용자 정보를 찾을 수 없습니다.',
-      });
-    }
+    // if (!userInfo) {
+    //   return res.status(400).send({
+    //     isSuccess: false,
+    //     code: 400,
+    //     error: '사용자 정보를 찾을 수 없습니다.',
+    //   });
+    // }
 
-    const userId = userInfo.id;
+    // const userId = userInfo.id;
+    const userId = '6549bb7f07eae932762e5e9f';
 
     // 사용자의 그룹 ID 목록 조회
     const userGroup = await User.findById(userId).select('groups');
+    console.log(userGroup, 'user의 그룹!!');
+    console.log(userGroup.groups);
     let groups = []; // 변수 선언 및 초기화
-
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
     if (userGroup) {
       // 그룹 ID 목록을 사용하여 그룹 정보 조회 (비동기 처리)
       groups = await Group.find({ _id: { $in: userGroup.groups } });
@@ -73,9 +75,10 @@ exports.getCategoryGroupsByUser = async (req, res) => {
       for (const group of groups) {
         const memberTimers = [];
         for (const memberId of group.members) {
-          const userTimer = await Timer.findOne({ user_id: memberId, 'daily.date': new Date() });
+          const userTimer = await Timer.find({ user_id: memberId, 'daily.date': today });
           if (userTimer) {
-            memberTimers.push({ userId: memberId, timerData: userTimer.daily.data });
+            console.log(userTimer, '<<<<<<<<');
+            memberTimers.push({ userId: memberId, timerData: userTimer.daily.date });
           }
         }
         group.memberTimers = memberTimers;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -23,6 +23,6 @@ router.use('/api/user', routerUser);
 router.use('/api/auth', routerAuth);
 
 // 랭킹 라우터
-router.use('/', routerCategory);
+router.use('/api', routerCategory);
 
 module.exports = router;

--- a/server/routes/routerGroup.js
+++ b/server/routes/routerGroup.js
@@ -9,6 +9,7 @@ const { groupImgUploader } = require('../middlewares/multer/multerConfig'); // �
 router.get('/studyGroups', verifyJwtToken, controller.getCategoryGroups);
 // 현재 로그인한 유저가 속한 스터디 그룹을 조회
 router.get('/studyGroups/users', verifyJwtToken, controller.getCategoryGroupsByUser);
+// router.get('/studyGroups/users', controller.getCategoryGroupsByUser);
 // 현재 로그인한 유저의 pending_group 조회
 router.get('/pendingGroups', verifyJwtToken, controller.getPendingGroups);
 //그룹 요청 기능

--- a/server/routes/routerTimer.js
+++ b/server/routes/routerTimer.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controller/ctrTimer');
+const { verifyJwtToken } = require('../middlewares/jwt/jwt');
+
+router.get('/timer', verifyJwtToken, controller.getMyTimer);
+
+module.exports = router;

--- a/server/schemas/index.js
+++ b/server/schemas/index.js
@@ -18,7 +18,6 @@ const connect = () => {
 
   // 몽고디비 연결시 이벤트 리스너
   mongoose.connection.on('connected', async () => {
-
     console.log(`${MONGO_HOST} 몽고디비 연결되었습니다.`);
   });
   // 데이터 강제로 입력

--- a/socketServer/schemas/schema.js
+++ b/socketServer/schemas/schema.js
@@ -70,7 +70,7 @@ const timerSchema = new Schema({
   user_id: { type: Schema.Types.ObjectId, ref: 'User' },
   total_time: { type: Number, default: 0 },
   daily: {
-    date: String, // 오늘 날짜
+    date: { type: Date, default: Date.now }, // 오늘 날짜
     data: [
       {
         title: { type: String }, // 과목

--- a/socketServer/utils/timer.js
+++ b/socketServer/utils/timer.js
@@ -19,7 +19,7 @@ module.exports = function (io) {
       }
     });
     console.log('client is connected in stopwatch!', socket.id);
-    const userId = socket.handshake.query.userId;
+    const userId = socket.handshake.auth.userId;
     const userGroupIds = await timerController.getUserGroups(userId);
 
     timerSpace.emit('welcome', userGroupIds); //배열로 유저가 속한 그룹의 objId를 보냄


### PR DESCRIPTION
- 랭킹을 클라이언트와 붙이기 위해서 라우터 경로에 /api를 추가하였습니다.
- 소켓 서버에서 타이머페이지에 접속 시 그룹아이디로 방에 입장하는데 그룹이 없어서 방에 입장하지 못하는 에러를 새로운 그룹을 만듦으로써 해결하였습니다.